### PR TITLE
[PKG-2502] minimal-snowplow-tracker 0.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,6 +6,7 @@ package:
   version: {{ version }}
 
 source:
+  # see also https://github.com/dbt-labs/snowplow-python-tracker/commit/bf630807ab93326ada84044a06a77ce2e9ce7b33
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: acabf7572db0e7f5cbf6983d495eef54081f71be392330eb3aadb9ccb39daaa4
 
@@ -35,7 +36,7 @@ test:
 
 about:
   home: https://www.getdbt.com/
-  # The source code is only avaialble her https://pypi.org/project/minimal-snowplow-tracker/#history
+  dev_url: https://github.com/dbt-labs/snowplow-python-tracker
   doc_url: https://pypi.org/project/minimal-snowplow-tracker/
   summary: A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,9 +38,9 @@ about:
   home: https://www.getdbt.com/
   dev_url: https://github.com/dbt-labs/snowplow-python-tracker
   doc_url: https://pypi.org/project/minimal-snowplow-tracker/
-  summary: A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
+  summary: Snowplow event tracker for Python
   description: |
-    A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
+    With this tracker you can collect event data from your Python-based applications, games or Python web servers/frameworks.
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,26 @@
 {% set name = "minimal-snowplow-tracker" %}
 {% set version = "0.0.2" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/minimal-snowplow-tracker-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: acabf7572db0e7f5cbf6983d495eef54081f71be392330eb3aadb9ccb39daaa4
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - requests >=2.2.1,<3.0
     - six >=1.9.0,<2.0
 
@@ -28,18 +28,24 @@ test:
   imports:
     - snowplow_tracker
     - snowplow_tracker.test
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
-  home: https://www.fishtownanalytics.com
-  dev_url: https://pypi.org/project/minimal-snowplow-tracker/
+  home: https://www.getdbt.com/
+  # The source code is only avaialble her https://pypi.org/project/minimal-snowplow-tracker/#history
+  doc_url: https://pypi.org/project/minimal-snowplow-tracker/
   summary: A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
+  description: |
+    A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:
     - thewchan
+  skip-lints:
+    - missing_dev_url


### PR DESCRIPTION
Requirements: the file `setup.py` is inside source distribution on PyPi https://files.pythonhosted.org/packages/e4/9f/004f810169a48ed5c520279d98327e7793b6491f09d42cb2c5636c994f34/minimal-snowplow-tracker-0.0.2.tar.gz 

Actions:
1. Clean up the recipe:
- Remove `noarch` python
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `setuptools` and `wheel` to `host`
2. Update `home` url
3. Add `doc_url` and a comment about missing `dev_url`
4. Add `description`
5. Skip a lint `missing_dev_url`

Notes:
- `dbt` requires it https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L58